### PR TITLE
testUrl method error: | separator urlencoded

### DIFF
--- a/Test/Case/View/Helper/ImagineHelperTest.php
+++ b/Test/Case/View/Helper/ImagineHelperTest.php
@@ -56,7 +56,7 @@ class ImagineHelperTest extends CakeTestCase {
 					'width' => 200,
 					'height' => 150)));
 		$expected = '/images/display/1/thumbnail:width|200;height|150/hash:69aa9f46cdc5a200dc7539fc10eec00f2ba89023';
-		$this->assertEqual($result, $expected);
+		$this->assertEqual(urldecode($result), $expected);
 	}
 
 /**


### PR DESCRIPTION
I get the following error, it seems the | separator comes urlencoded:

```
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'/images/display/1/thumbnail:width|200;height|150/hash:69aa9f46cdc5a200dc7539fc10eec00f2ba89023'
+'/images/display/1/thumbnail:width%7C200%3Bheight%7C150/hash:69aa9f46cdc5a200dc7539fc10eec00f2ba89023'
```
