### PR TITLE
Changed order of the arguments in url method

### DIFF
--- a/Test/Case/View/Helper/ImagineHelperTest.php
+++ b/Test/Case/View/Helper/ImagineHelperTest.php
@@ -51,12 +51,39 @@ class ImagineHelperTest extends CakeTestCase {
 				'controller' => 'images',
 				'action' => 'display',
 				1),
+      false,
 			array(
 				'thumbnail' => array(
 					'width' => 200,
 					'height' => 150)));
 		$expected = '/images/display/1/thumbnail:width|200;height|150/hash:69aa9f46cdc5a200dc7539fc10eec00f2ba89023';
 		$this->assertEqual($result, $expected);
+	}
+  
+/**
+ * testUrl method for backward compatibility
+ *
+ * @return void
+ */
+	public function testUrlBackwardCompatibility() {
+    $param1 = array(
+      'controller' => 'images',
+			'action' => 'display',
+			1
+    );
+    $param2 = false;
+    $param3 = array(
+      'thumbnail' => array(
+        'width' => 200,
+				'height' => 150
+       )
+    );
+
+    $result1 = $this->Imagine->url($param1, $param2, $param3);
+    $result2 = $this->Imagine->url($param1, $param3, $param2);
+
+    $this->assertEquals($result1, $result2);
+
 	}
 
 /**

--- a/View/Helper/ImagineHelper.php
+++ b/View/Helper/ImagineHelper.php
@@ -34,15 +34,23 @@ class ImagineHelper extends AppHelper {
  *                        or an array specifying any of the following: 'controller', 'action',
  *                        and/or 'plugin', in addition to named arguments (keyed array elements),
  *                        and standard URL arguments (indexed array elements)
- * @param array $options List of named arguments that need to sign
  * @param boolean $full If true, the full base URL will be prepended to the result
+ * @param array $options List of named arguments that need to sign
  * @return string Full translated signed URL with base path and with
  * @access public
  */
-	public function url($url = array(), $options, $full = false) {
+	public function url($url = null, $full = false, $options = array()) {
 		if (is_string($url)) {
 			$url = array_merge(array('plugin' => 'media', 'admin' => false, 'controller' => 'media', 'action' => 'image'), array($url));
 		}
+    
+    // backward compatibility check, switches params 2 and 3
+    if (is_bool($options)) {
+      $tmp = $options;
+      $options = $full;
+      $full = $tmp;
+    }
+    
 		$options = $this->pack($options);
 		$options['hash'] = $this->hash($options);
 


### PR DESCRIPTION
Running plugin test with PHP 5.4.9, CakePHP 2.3.6 and PHPUnit: 3.7.19, I get the following error:

```
Running ImagineHelperTest
PHPUnit_Framework_Error_Notice
Declaration of ImagineHelper::url() should be compatible with Helper::url($url = NULL, $full = false)
Test case: ImagineHelperTest(testUrl)
Stack trace:
/.../app/Plugin/Imagine/View/Helper/ImagineHelper.php : 19
/.../lib/Cake/Core/App.php : 563
App::load
/.../app/Plugin/Imagine/Test/Case/View/Helper/ImagineHelperTest.php : 31
/usr/share/php/PHPUnit/Framework/TestCase.php : 828
/usr/share/php/PHPUnit/Framework/TestResult.php : 648
/usr/share/php/PHPUnit/Framework/TestCase.php : 776
/.../lib/Cake/TestSuite/CakeTestCase.php : 84
/usr/share/php/PHPUnit/Framework/TestSuite.php : 775
/usr/share/php/PHPUnit/Framework/TestSuite.php : 745
/usr/share/php/PHPUnit/TextUI/TestRunner.php : 349
/.../lib/Cake/TestSuite/CakeTestRunner.php : 63
/.../lib/Cake/TestSuite/CakeTestSuiteCommand.php : 115
/.../lib/Cake/TestSuite/CakeTestSuiteDispatcher.php : 247
/.../lib/Cake/TestSuite/CakeTestSuiteDispatcher.php : 100
/.../lib/Cake/TestSuite/CakeTestSuiteDispatcher.php : 117
/.../app/webroot/test.php : 98
```

The solution suggested here changes the order of the arguments in the url method, but (thanks @dogmatic69) incorporates also a small workaround to try to ensure backward compatibility.
