### PR TITLE
Fixing strict standards warning

### DIFF
--- a/Test/Case/Lib/ImagineUtilityTest.php
+++ b/Test/Case/Lib/ImagineUtilityTest.php
@@ -23,17 +23,19 @@ class ImagineUtilityTest extends CakeTestCase {
 /**
  * startTest
  *
+ * @param string $method Test method about to get executed.
  * @return void
  */
-	public function startTest() {
+	public function startTest($method) {
 	}
 
 /**
  * endTest
  *
+ * @param string $method Test method about that was executed.
  * @return void
  */
-	public function endTest() {
+	public function endTest($method) {
 	}
 
 /**


### PR DESCRIPTION
Strict standards: Declaration of ImagineUtilityTest::startTest() should be compatible with CakeTestCase::startTest($method) in /.../app/Plugin/Imagine/Test/Case/Lib/ImagineUtilityTest.php on line 14

Strict standards: Declaration of ImagineUtilityTest::endTest() should be compatible with CakeTestCase::endTest($method) in /.../app/Plugin/Imagine/Test/Case/Lib/ImagineUtilityTest.php on line 14
