### PR TITLE
Updated composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,5 @@
  			"Cake\\Test\\": "/vendor/cakephp/cakephp/tests",
  			"Burzum\\Imagine\\Test\\": "tests"
  		}
- 	},
-	"scripts": {
-		"post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump"
-	}
+ 	}
 }


### PR DESCRIPTION
The `"post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump"` must be in application composer.json not in plugin one.